### PR TITLE
added Registry contract and interface contracts.

### DIFF
--- a/SmartContract/src/ERC6551Registry.sol
+++ b/SmartContract/src/ERC6551Registry.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "openzeppelin/utils/Create2.sol";
+import "./interfaces/IERC6551Registry.sol";
+import "./lib/ERC6551BytecodeLib.sol";
+
+
+//**FYI- We will only need to use the interface(IERC6551Registry) for testing if we fork mainnet,
+// we can use this if we are running all the contracts on local evm
+contract ERC6551Registry is IERC6551Registry {
+    error InitializationFailed();
+
+    function createAccount(
+        address implementation,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 salt,
+        bytes calldata initData
+    ) external returns (address) {
+        bytes memory code = ERC6551BytecodeLib.getCreationCode(
+            implementation,
+            chainId,
+            tokenContract,
+            tokenId,
+            salt
+        );
+
+        address _account = Create2.computeAddress(bytes32(salt), keccak256(code));
+
+        if (_account.code.length != 0) return _account;
+
+        emit AccountCreated(_account, implementation, chainId, tokenContract, tokenId, salt);
+
+        _account = Create2.deploy(0, bytes32(salt), code);
+
+        if (initData.length != 0) {
+            (bool success, ) = _account.call(initData);
+            if (!success) revert InitializationFailed();
+        }
+
+        return _account;
+    }
+
+    function account(
+        address implementation,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 salt
+    ) external view returns (address) {
+        bytes32 bytecodeHash = keccak256(
+            ERC6551BytecodeLib.getCreationCode(
+                implementation,
+                chainId,
+                tokenContract,
+                tokenId,
+                salt
+            )
+        );
+
+        return Create2.computeAddress(bytes32(salt), bytecodeHash);
+    }
+}

--- a/SmartContract/src/interfaces/IERC6551Registry.sol
+++ b/SmartContract/src/interfaces/IERC6551Registry.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC6551Registry {
+    event AccountCreated(
+        address account,
+        address implementation,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 salt
+    );
+
+    function createAccount(
+        address implementation,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 seed,
+        bytes calldata initData
+    ) external returns (address);
+
+    function account(
+        address implementation,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 salt
+    ) external view returns (address);
+}

--- a/SmartContract/test/SimpleAccountTest.sol
+++ b/SmartContract/test/SimpleAccountTest.sol
@@ -2,34 +2,44 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
+import "openzeppelin/token/ERC721/ERC721.sol";
 import "../src/SimpleERC6551Account.sol";
+
 
 contract SimpleAccountTest is Test {
     SimpleERC6551Account public simpleAccount;
     address internal alice;
     address internal bob;
     address payable[] internal users;
-    //TODO: import ExpirableERC721 and create instance of that to set up test
+    ERC721 nft;
 
+    //TODO: import ExpirableERC721 and create instance of that to set up test
+    //      Will need to fork mainnet if using existing registry, or create new registry and run it all locally.
     function setUp() public {
-       
+        nft = new ERC721("ExpirableERC721","EXP");
         simpleAccount = new SimpleERC6551Account();
         alice = users[0];
         bob = users[1];
     }
 
-/*
-function executeCall(
-        address to,
-        uint256 value,
-        bytes calldata data
-    ) external payable returns (bytes memory result)
-*/
+    // function createAccount() public {
+    // simpleAccount.executeCall()
+    //     assertEq());
+    // }
 
     // function testExecute() public {
-       // simpleAccount.executeCall()
+    // simpleAccount.executeCall()
     //     assertEq());
     // }
 
 
+
+
+    /*
+    function executeCall(
+        address to,
+        uint256 value,
+        bytes calldata data
+    ) external payable returns (bytes memory result)
+    */
 }


### PR DESCRIPTION
Set up scaffolding for testing ERC6551Account which holds ExpirableERC721 and which can createAccounts with ERC6551Registry. 
 
added Registry Interface so we can either:
a) fork mainnet with the current registry address
b)deploy our own registry and run contracts locally for demo purposes.